### PR TITLE
Add static type checking using Flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+.*/node_modules/.*
+[include]
+
+[libs]
+
+[options]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,21 @@ Contributing guidelines
 * Pull requests must contain a succinct, clear summary of what the user need is driving this feature change
 * Ensure your branch contains logical atomic commits before sending a pull request - follow the [alphagov Git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)
 * You may rebase your branch after feedback if it's to include relevant updates from the develop branch. We prefer a rebase here to a merge commit as we prefer a clean and straight history on develop with discrete merge commits for features
+
+### Type Annotation Using [Flow](https://flow.org/en/)
+
+* We use Flow as a static type checker for all files in /utils.
+
+Example:
+
+```javascript
+// Type annotate variables:
+const hello: String = "Hello, world!";
+
+// And methods:
+logout(callback: (success: boolean) => void) {
+  ...
+}
+```
+
+* Use `npm run flow` to check for Flow type warnings/errors

--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "flow-bin": "^0.48.0",
+    "jasmine": "^2.5.3",
+    "jasmine-node": "^1.14.5",
     "mocha": "^3.0.2",
     "mz": "^2.4.0",
     "react-scripts": "0.2.1",
+    "selenium-webdriver": "^3.3.0",
     "supertest": "^3.0.0",
-    "supertest-as-promised": "^4.0.0",
-    "jasmine": "^2.5.3",
-    "jasmine-node": "^1.14.5",
-    "selenium-webdriver": "^3.3.0"
+    "supertest-as-promised": "^4.0.0"
   },
   "dependencies": {
     "base-64": "^0.1.0",
@@ -48,7 +49,8 @@
     "restart": "react-scripts start",
     "build": "react-scripts build",
     "eject": "react-scripts eject",
-    "test": "SERVE_HTML=true mocha test/server.test.js; NODE_ENV=test jasmine test/integration-test.js"
+    "test": "SERVE_HTML=true mocha test/server.test.js; NODE_ENV=test jasmine test/integration-test.js",
+    "flow": "flow"
   },
   "eslintConfig": {
     "extends": "./node_modules/react-scripts/config/eslint.js",

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,3 +1,5 @@
+// @flow
+
 /**
  * Authentication lib
  * @type {Object}
@@ -9,7 +11,7 @@ var auth = {
    * @param  {string}   password The password of the user
    * @param  {Function} callback Called after a user was logged in on the remote server
    */
-  login(username, password, callback) {
+  login(username: String, password: String, callback: (success: boolean, data: {}) => void) {
     // Do not need to check if user is already logged in, this is done in
     // routes.js before this method is called
 
@@ -23,9 +25,9 @@ var auth = {
     }).then( (response) => {
       if (response.status === 200){
         return response.json().then(function(json) {
-          const apiKey = json.apiKey;
-          const role = json.role;
-          const token = json.token;
+          const apiKey: String = json.apiKey;
+          const role: String = json.role;
+          const token: String = json.token;
           sessionStorage.setItem('token', token);
           //send auth request to save token username pair
           callback(true,{ apiKey, role, token });
@@ -35,7 +37,7 @@ var auth = {
       }
     });
   },
-  checkToken(token,callback){
+  checkToken(token: String, callback: (success: boolean, data: ?{}) => void){
     fetch("http://localhost:3001/checkToken", {
       method: 'POST',
       headers: {
@@ -45,9 +47,9 @@ var auth = {
     }).then( (response) => {
       if (response.status === 200){
         return response.json().then(function(json) {
-          const apiKey = json.apiKey;
-          const role = json.role;
-          const token = json.token;
+          const apiKey: String = json.apiKey;
+          const role: String = json.role;
+          const token: String = json.token;
           //send auth request to save token username pair
           callback(true,{authenticated: true,apiKey,role,token});
         });
@@ -59,8 +61,8 @@ var auth = {
   /**
    * Logs the current user out
    */
-  logout(callback) {
-    const token = sessionStorage.token;
+  logout(callback: (success: boolean) => void) {
+    const token: String = sessionStorage.token;
     fetch("http://localhost:3001/logout", {
       method: 'POST',
       headers: {


### PR DESCRIPTION
Add Flow static type checking. Now all files with the `// @Flow` annotation will be type checked by Flow when `npm run flow` is run.

- Add flow-bin to package.json
- Add flow to package.json scripts section
- Add .flowconfig file, set to ignore node_modules
- Type annotated /utils/auth.js
- Add Flow details in CONTRIBUTING.md