### PR TITLE
Fix use of prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "supertest-as-promised": "^4.0.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.10",
     "base-64": "^0.1.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.17.2",

--- a/src/components/LoginErrorMessage.js
+++ b/src/components/LoginErrorMessage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { ListGroup, ListGroupItem } from 'react-bootstrap';
 
@@ -9,6 +10,7 @@ const ErrorMessage = (props) => {
   </ListGroup>) : (<div></div>)
   );
 };
+
 
 ErrorMessage.propTypes = {
   errorMessage: PropTypes.string.isRequired,

--- a/src/templates/Header.js
+++ b/src/templates/Header.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ONSLogo from '../resources/img/orglogo.svg';
 
-class Header extends Component {
+class Header extends React.Component {
   constructor(props) {
     super(props);
     this.state = {

--- a/src/templates/NavBar.js
+++ b/src/templates/NavBar.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Navbar, Nav, NavItem } from 'react-bootstrap';
 import Button from 'react-bootstrap-button-loader';
 import { IndexLinkContainer } from 'react-router-bootstrap';
@@ -7,7 +8,7 @@ import { Link } from 'react-router';
 import { logout } from '../actions/AppActions';
 import '../resources/css/mycss.css';
 
-class NavBar extends Component {
+class NavBar extends React.Component {
   constructor() {
     super();
     this.onLogout = this.onLogout.bind(this);

--- a/src/templates/Template.js
+++ b/src/templates/Template.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Header from './Header';
 import NavBar from './NavBar';
 

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -1,11 +1,12 @@
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Button from 'react-bootstrap-button-loader';
 import { Alert } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { login } from '../actions/AppActions';
 import ErrorMessage from '../components/LoginErrorMessage';
 
-class Login extends Component {
+class Login extends React.Component {
   constructor(props) {
     super(props);
     this.state = {


### PR DESCRIPTION
- Fix warning (warning still exists, due to false positive) related to using PropTypes from React, rather than an external library
- Use ES6 classes for react components