### PR TITLE
Add package.json for the server

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "sbr-ui",
+  "version": "0.0.1",
+  "private": false,
+  "license": "MIT",
+  "description": "A user interface for the Statistical Business Register.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ONSdigital/sbr-ui.git"
+  },
+  "dependencies": {
+    "base-64": "^0.1.0",
+    "body-parser": "^1.17.2",
+    "express": "^4.14.0",
+    "jsonwebtoken": "^7.1.9",
+    "jwt-decode": "^2.2.0",
+    "morgan": "^1.7.0"
+  },
+  "engines": {
+    "node": "5.10.1",
+    "npm": "3.8.3"
+  },
+  "scripts": {
+    "start": "SERVE_HTML=true ENV=local node index.js"
+  }
+}


### PR DESCRIPTION
- Add package.json in /server with just server dependancies, to ensure when node_modules are being zipped and put into CloudFoundry, only the Node/Express server dependancies are transferred.