### PR TITLE
Add server/node_modules to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 coverage/**/**/*.js
 test/**/**/*.js
 build/**/**/*.js
+server/node_modules/**/**/*.js


### PR DESCRIPTION
- Eslint gave errors in server/node_modules so add to .eslintignore, node modules in parent folder are ignored by default