### PR TITLE
Fix/multiple ref results

### DIFF
--- a/src/actions/ApiActions.js
+++ b/src/actions/ApiActions.js
@@ -22,7 +22,7 @@ export function refSearch(query) {
           headers: data.response,
         }));
         if (data.results.length === 1) {
-          browserHistory.push(`/Search/${query}`);
+          browserHistory.push(`/Search/${query}/0`);
         }
       } else {
         dispatch(setErrorMessage(SET_REF_ERROR_MESSAGE, data.message));

--- a/src/components/EnterprisePanel.js
+++ b/src/components/EnterprisePanel.js
@@ -10,7 +10,7 @@ const EnterprisePanel = function ({ enterprise, defaultExpand }) {
     &nbsp;&nbsp;{enterprise.name}, Source: {enterprise.source}
   </h1>);
   return (
-    <Panel bsStyle="primary" collapsible defaultExpanded={defaultExpand} header={title}>
+    <Panel bsStyle="primary" collapsible={false} defaultExpanded header={title}>
       <ListGroup fill>
         <ListGroupItem>
           <Table striped bordered condensed hover>

--- a/src/components/EnterprisePanel.js
+++ b/src/components/EnterprisePanel.js
@@ -7,10 +7,10 @@ import DeveloperView from './DeveloperView';
 const EnterprisePanel = function ({ enterprise, defaultExpand }) {
   const title = (<h1 style={{ fontSize: '30px' }}>
     <Glyphicon style={{ fontSize: '28px', verticalAlign: 'middle', marginBottom: '2px' }} glyph="briefcase" />
-    &nbsp;&nbsp;{enterprise.enterprise}
+    &nbsp;&nbsp;{enterprise.name}, Source: {enterprise.source}
   </h1>);
   return (
-    <Panel collapsible defaultExpanded={defaultExpand} header={title}>
+    <Panel bsStyle="primary" collapsible defaultExpanded={defaultExpand} header={title}>
       <ListGroup fill>
         <ListGroupItem>
           <Table striped bordered condensed hover>
@@ -22,7 +22,7 @@ const EnterprisePanel = function ({ enterprise, defaultExpand }) {
             </thead>
             <tbody>
               <tr>
-                <td>{enterprise.idbr}</td>
+                <td>{enterprise.enterprise}</td>
                 <td>{enterprise.sbrEntRef}</td>
               </tr>
             </tbody>

--- a/src/config/api-urls.js
+++ b/src/config/api-urls.js
@@ -1,6 +1,7 @@
 const apiUrls = {
   AUTH_URL: 'http://localhost:3001',
-  API_URL: 'http://localhost:9000/v1',
+  API_URL: 'http://localhost:9000',
+  API_VERSION: 'v1',
 };
 
 export default apiUrls;

--- a/src/routes.js
+++ b/src/routes.js
@@ -49,7 +49,7 @@ const Routes = () => (
         <Route onEnter={checkAuthentication} >
           <Route path={'/Home'} component={Home} />
           <Route path={'/Search'} component={Search} />
-          <Route path={'/Search/:id'} component={EnterpriseView} />
+          <Route path={'/Search/:enterprise/:index'} component={EnterpriseView} />
           <Route path={'/Help'} component={Help} />
           <Route path={'/Support'} component={Support} />
           <Route path={'/*'} component={NotFound} />

--- a/src/utils/apiInfo.js
+++ b/src/utils/apiInfo.js
@@ -37,11 +37,8 @@ const apiInfo = {
    * @param  {Function} callback Called with returned data.
    */
   getApiInfo(callback: (success: boolean, data: {}) => void) {
-    fetch(`${API_URL}/info`, {
+    fetch(`${API_URL}/version`, {
       method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
     }).then((response) => {
       if (response.status === 200) {
         return response.json().then((json) => {

--- a/src/utils/apiSearch.js
+++ b/src/utils/apiSearch.js
@@ -2,7 +2,7 @@
 
 import config from '../config/api-urls';
 
-const { API_URL } = config;
+const { API_URL, API_VERSION } = config;
 
 /**
  * API lib for getting info (version/last updated etc.)
@@ -14,11 +14,8 @@ const apiSearch = {
    * @param  {Function} callback Called with returned data.
    */
   getRef(id: string, callback: (success: boolean, data: {}) => void) {
-    fetch(`${API_URL}/search?id=${id}`, {
+    fetch(`${API_URL}/${API_VERSION}/search?id=${id}`, {
       method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
     }).then((response) => {
       if (response.status === 200) {
         return response.json().then((json) => {

--- a/src/views/EnterpriseView.js
+++ b/src/views/EnterpriseView.js
@@ -1,26 +1,23 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { PageHeader } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import EnterprisePanel from '../components/EnterprisePanel';
 
-const EnterpriseView = function ({ data }) {
+const EnterpriseView = function ({ routeParams, data }) {
   return (
     <div>
       <PageHeader>Enterprise View</PageHeader>
       <EnterprisePanel
-        key={data[0].ubrn}
-        defaultExpand
-        enterprise={data[0]}
+        key={data[routeParams.index].ubrn}
+        enterprise={data[routeParams.index]}
       />
     </div>
   );
 };
 
 EnterpriseView.propTypes = {
-  data: React.PropTypes.shape({
-    name: PropTypes.string.isRequired,
-  }).isRequired,
+  data: React.PropTypes.object.isRequired,
+  routeParams: React.PropTypes.object.isRequired,
 };
 
 function select(state) {

--- a/src/views/EnterpriseView.js
+++ b/src/views/EnterpriseView.js
@@ -4,26 +4,24 @@ import { PageHeader } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import EnterprisePanel from '../components/EnterprisePanel';
 
-class EnterpriseView extends React.Component {
-  render() {
-    return (
-      <div>
-        <PageHeader>Enterprise View</PageHeader>
-        <EnterprisePanel
-          key={this.props.data[0].idbr}
-          defaultExpand={true}
-          enterprise={this.props.data[0]}
-        />
-      </div>
-    );
-  }
-}
+const EnterpriseView = function ({ data }) {
+  return (
+    <div>
+      <PageHeader>Enterprise View</PageHeader>
+      <EnterprisePanel
+        key={data[0].ubrn}
+        defaultExpand
+        enterprise={data[0]}
+      />
+    </div>
+  );
+};
 
-// EnterpriseView.propTypes = {
-//   data: React.PropTypes.shape({
-//     name: PropTypes.string.isRequired,
-//   }).isRequired,
-// };
+EnterpriseView.propTypes = {
+  data: React.PropTypes.shape({
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+};
 
 function select(state) {
   return {

--- a/src/views/Search.js
+++ b/src/views/Search.js
@@ -65,7 +65,7 @@ class Search extends React.Component {
     this.props.dispatch(setQuery(SET_REF_QUERY, evt.target.value));
   }
   displayEnterprises() {
-    const tableRows = this.props.data.results.map((enterprise) => {
+    const tableRows = this.props.data.results.map((enterprise, index) => {
       return (
         <tr>
           <td>{enterprise.enterprise}</td>
@@ -73,7 +73,7 @@ class Search extends React.Component {
           <td>{enterprise.name}</td>
           <td>
             <Button
-              onClick={() => browserHistory.push(`/Search/${enterprise.enterprise}`)}
+              onClick={() => browserHistory.push(`/Search/${enterprise.enterprise}/${index}`)}
               bsStyle="info"
             >
                 Go to record

--- a/src/views/Search.js
+++ b/src/views/Search.js
@@ -69,8 +69,8 @@ class Search extends React.Component {
       return (
         <tr>
           <td>{enterprise.enterprise}</td>
-          <td>{enterprise.name}</td>
           <td>{enterprise.source}</td>
+          <td>{enterprise.name}</td>
           <td>
             <Button
               onClick={() => browserHistory.push(`/Search/${enterprise.enterprise}`)}
@@ -87,8 +87,8 @@ class Search extends React.Component {
         <thead>
           <tr>
             <th style={{ width: '120px' }}>ID</th>
-            <th >Name</th>
             <th style={{ width: '80px' }}>Source</th>
+            <th >Name</th>
             <th style={{ width: '120px' }}></th>
           </tr>
         </thead>

--- a/src/views/Search.js
+++ b/src/views/Search.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { PageHeader } from 'react-bootstrap';
+import { PageHeader, Button, Table } from 'react-bootstrap';
 import { connect } from 'react-redux';
+import { browserHistory } from 'react-router';
 import { refSearch, setQuery } from '../actions/ApiActions';
 import { SET_REF_QUERY } from '../constants/ApiConstants';
 import ErrorModal from '../components/ErrorModal';
 import SearchRefForm from '../components/SearchRefForm';
-import EnterprisePanel from '../components/EnterprisePanel';
 
 class Search extends React.Component {
   constructor(props) {
@@ -64,16 +64,42 @@ class Search extends React.Component {
     // presses 'back to search' on the Enterprise View page.
     this.props.dispatch(setQuery(SET_REF_QUERY, evt.target.value));
   }
-  render() {
-    const results = this.state.results.map((enterprise) => {
+  displayEnterprises() {
+    const tableRows = this.props.data.results.map((enterprise) => {
       return (
-        <EnterprisePanel
-          key={enterprise.idbr}
-          defaultExpand={false}
-          enterprise={enterprise}
-        />
+        <tr>
+          <td>{enterprise.enterprise}</td>
+          <td>{enterprise.name}</td>
+          <td>{enterprise.source}</td>
+          <td>
+            <Button
+              onClick={() => browserHistory.push(`/Search/${enterprise.enterprise}`)}
+              bsStyle="info"
+            >
+                Go to record
+            </Button>
+          </td>
+        </tr>
       );
     });
+    return (
+      <Table style={{ width: '75%' }} striped bordered condensed hover>
+        <thead>
+          <tr>
+            <th style={{ width: '120px' }}>ID</th>
+            <th >Name</th>
+            <th style={{ width: '80px' }}>Source</th>
+            <th style={{ width: '120px' }}></th>
+          </tr>
+        </thead>
+        <tbody>
+          {tableRows}
+        </tbody>
+      </Table>
+    );
+  }
+  render() {
+    const results = this.displayEnterprises();
     const enterprises = (this.props.data.results.length > 1) ? results : <div></div>;
     return (
       <div>


### PR DESCRIPTION
Add table of results on Search page if multiple results are returned, a button takes a user to the full enterprise page at `/Search/:enterprise/:index`. 

If one result is returned, the user will be taken straight to `/Search/:enterprise/0`.