### PR TITLE
Fix 'use strict' issue that breaks CF deploy

### DIFF
--- a/server/formatDate.js
+++ b/server/formatDate.js
@@ -1,3 +1,8 @@
+'use strict';
+
+// Rule exceptions:
+/* eslint strict: "off" */
+
 function formatDate(date) {
   let dd = date.getDate();
   let mm = date.getMonth() + 1;


### PR DESCRIPTION
- Need 'use strict' at top of any js that is run by node, to allow the use of const/let etc