### PR TITLE
Fix/psql init

### DIFF
--- a/server/sessions/PsqlSession.js
+++ b/server/sessions/PsqlSession.js
@@ -19,7 +19,7 @@ class PsqlSession extends Session {
     // The pool will emit an error on behalf of any idle clients it
     // contains if a backend error or network partition occurs
     this.pool.on('error', (err, client) => {
-      logger.error('Unexpected error on idle client', err);
+      logger.error('PostgreSQL connection error: Unexpected error on idle client', err);
       process.exit(-1);
     });
   }


### PR DESCRIPTION
- Add small fix that was supposed to be included in the last PR
- Fix issue where on importing `PsqlSession.js`, the connection pool to PostgreSQL would be initialized, change to call the init code in the class constructor instead